### PR TITLE
Rename response methods

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -46,23 +46,15 @@ class Server
         }
     }
 
-    final public function respondToWellKnownRequest() : Response
-    {
-        $response = $this->response;
-
-        $serverConfig = $this->config->getServer();
-
-        return $this->createJsonResponse($response, $serverConfig);
-    }
-
-    final public function respondToJwksRequest(/*Jwks $jwks*/) : Response
-    {
-        $response = $this->response;
-        $key = $this->config->getKeys()->getPublicKey();
-
-        $jwks = new Jwks($key);
-
-        return $this->createJsonResponse($response, $jwks);
+    /**
+     * @param Request $request
+     *
+     * @return Response
+     *
+     * @see https://openid.net/specs/openid-connect-registration-1_0.html
+     */
+    final public function respondToDynamicClientRegistrationRequest(Request $request): Response {
+        return $this->response->withStatus(501);
     }
 
     final public function respondToAuthorizationRequest(
@@ -116,6 +108,27 @@ class Server
 
         return $response;
     }
+
+    final public function respondToJwksMetadataRequest(/*Jwks $jwks*/) : Response
+    {
+        $response = $this->response;
+        $key = $this->config->getKeys()->getPublicKey();
+
+        $jwks = new Jwks($key);
+
+        return $this->createJsonResponse($response, $jwks);
+    }
+
+    final public function respondToOpenIdMetadataRequest() : Response
+    {
+        $response = $this->response;
+
+        $serverConfig = $this->config->getServer();
+
+        return $this->createJsonResponse($response, $serverConfig);
+    }
+
+    final public function respondTo_Request(): Response {}
 
     ////////////////////////////// UTILITY METHODS \\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 

--- a/tests/example.php
+++ b/tests/example.php
@@ -89,9 +89,13 @@ $server = new \Pdsinterop\Solid\Auth\Server($authorizationServer, $config, $resp
 // Handle requests
 // -----------------------------------------------------------------------------
 switch ($request->getMethod() . $request->getRequestTarget()) {
+    case 'GET/.well-known/jwks.json':
+        $response = $server->respondToJwksMetadataRequest();
+        break;
+
     // @CHECKME: Do we also need 'GET/.well-known/oauth-authorization-server'?
     case 'GET/.well-known/openid-configuration':
-        $response = $server->respondToWellKnownRequest();
+        $response = $server->respondToOpenIdMetadataRequest();
         break;
 
     case 'POST/access_token':


### PR DESCRIPTION
- Rename `Server::respondToWellKnownRequest()` tp the more descriptive `Server::respondToOpenIdMetadataRequest()`
- Rename `Server::respondToJwksRequest()` to `Server::respondToJwksMetadataRequest()` for the sake of consistency
- Add an empty `Server::respondToDynamicClientRegistrationRequest()` that can already be consumed by implementing