### PR TITLE
Change Client config to support Redirect URIs and Name

### DIFF
--- a/src/Config/Client.php
+++ b/src/Config/Client.php
@@ -7,11 +7,11 @@ class Client
     ////////////////////////////// CLASS PROPERTIES \\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
     /** @var string */
-    private $authorizationPageUrl;
-    /** @var string */
     private $identifier;
     /** @var string */
-    private $loginUrl;
+    private $name;
+    /** @var array */
+    private $redirectUris;
     /** @var string */
     private $secret;
 
@@ -22,28 +22,32 @@ class Client
         return $this->identifier;
     }
 
+    final public function getName() : string
+    {
+        return $this->name;
+    }
+
+    final public function getRedirectUris() : array
+    {
+        return $this->redirectUris;
+    }
+
     final public function getSecret() : string
     {
         return $this->secret;
     }
 
-    final public function getAuthorizationPageUrl() : string
-    {
-        return $this->authorizationPageUrl;
-    }
-
-    final public function getLoginUrl() : string
-    {
-        return $this->loginUrl;
-    }
-
     //////////////////////////////// PUBLIC API \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
-    final public function __construct(string $identifier, string $secret, string $authorizationPageUrl = '', string $loginUrl = '')
-    {
-        $this->authorizationPageUrl = $authorizationPageUrl;
+    final public function __construct(
+        string $identifier,
+        string $secret,
+        array $redirectUris,
+        string $name = ''
+    ) {
         $this->identifier = $identifier;
-        $this->loginUrl = $loginUrl;
+        $this->name = $name;
+        $this->redirectUris = $redirectUris;
         $this->secret = $secret;
     }
 }

--- a/src/Factory/AuthorizationServerFactory.php
+++ b/src/Factory/AuthorizationServerFactory.php
@@ -25,14 +25,19 @@ class AuthorizationServerFactory
     {
         $config = $this->config;
 
-        $clientIdentifier = $config->getClient()->getIdentifier();
-        $clientSecret = $config->getClient()->getSecret();
+        $client = $config->getClient();
         $expiration = $config->getExpiration();
         $grantTypes = $config->getGrantTypes();
         $keys = $config->getKeys();
 
         $repositoryFactory = new RepositoryFactory([
-            Repository::CLIENT => new Client($clientIdentifier, $clientSecret, '',$grantTypes, []),
+            Repository::CLIENT => new Client(
+                $client->getIdentifier(),
+                $client->getSecret(),
+                $client->getName(),
+                $grantTypes,
+                $client->getRedirectUris()
+            ),
         ]);
 
         $server = new AuthorizationServer(

--- a/src/Factory/ConfigFactory.php
+++ b/src/Factory/ConfigFactory.php
@@ -10,10 +10,8 @@ use Pdsinterop\Solid\Auth\Enum\Time;
 
 class ConfigFactory
 {
-    /** @var string */
-    private $clientIdentifier;
-    /** @var string */
-    private $clientSecret;
+    /** @var Config\Client */
+    private $client;
     /** @var string */
     private $encryptionKey;
     /** @var string */
@@ -24,15 +22,13 @@ class ConfigFactory
     private $serverConfig;
 
     final public function __construct(
-        string $clientIdentifier,
-        string $clientSecret,
+        Config\Client $client,
         string $encryptionKey,
         string $privateKey,
         string $publicKey,
         array $serverConfig
     ) {
-        $this->clientIdentifier = $clientIdentifier;
-        $this->clientSecret = $clientSecret;
+        $this->client = $client;
         $this->encryptionKey = $encryptionKey;
         $this->privateKey = $privateKey;
         $this->serverConfig = $serverConfig;
@@ -41,13 +37,10 @@ class ConfigFactory
 
     final public function create() : Config
     {
-        $clientIdentifier = $this->clientIdentifier;
-        $clientSecret = $this->clientSecret;
+        $client = $this->client;
         $encryptionKey = $this->encryptionKey;
         $privateKey = $this->privateKey;
         $publicKey = $this->publicKey;
-
-        $client = new Config\Client($clientIdentifier, $clientSecret);
 
         $expiration = new Config\Expiration(Time::HOURS_1, Time::MINUTES_10, Time::MONTHS_1);
 

--- a/tests/example.php
+++ b/tests/example.php
@@ -21,10 +21,17 @@ $clientIdentifier = \array_key_exists(\Pdsinterop\Solid\Auth\Enum\OAuth2\Paramet
     ? $request->getQueryParams()[\Pdsinterop\Solid\Auth\Enum\OAuth2\Parameter::CLIENT_ID]
     : '';
 
-/*/ These should come from a database, based on $clientIdentifier /*/
+/*/ These should come from a database, based on $clientIdentifier
+ *
+ * They have previously been provided to or by the Client, using a Dynamic
+ * Registration request.
+/*/
+$clientName = 'Example Client Name';
+$clientRedirectUris = [
+    'https://server/client/redirect-url',
+    'https://server/client/another-redirect-url',
+];
 $clientSecret = 'client secret';
-$clientName = '';
-$clientRedirectUri = ['https://server/client/redirect-url'];
 // =============================================================================
 
 
@@ -37,11 +44,13 @@ $privateKey = file_get_contents($keyPath . '/private.key');
 $publicKey = file_get_contents($keyPath . '/public.key');
 
 $config = (new \Pdsinterop\Solid\Auth\Factory\ConfigFactory(
-    $clientIdentifier,
-    $clientSecret,
-    $encryptionKey,
-    $privateKey,
-    $publicKey,
+    new \Pdsinterop\Solid\Auth\Config\Client(
+        $clientIdentifier,
+        $clientSecret,
+        $clientRedirectUris,
+        $clientName
+    ),
+    $encryptionKey,$privateKey, $publicKey,
     [
         /* URL of the OP's OAuth 2.0 Authorization Endpoint [OpenID.Core]. */
         \Pdsinterop\Solid\Auth\Enum\OpenId\OpenIdConnectMetadata::AUTHORIZATION_ENDPOINT => 'https://server/authorize',


### PR DESCRIPTION
These values need to be set from the outside, so the Client config object now needs to be created by the implementing application.