### PR TITLE
Add support for the OAuth2 "Implicit" grant flow.

### DIFF
--- a/src/Factory/ConfigFactory.php
+++ b/src/Factory/ConfigFactory.php
@@ -47,6 +47,7 @@ class ConfigFactory
         $grantTypes = [
             GrantType::AUTH_CODE,
             GrantType::CLIENT_CREDENTIALS,
+            GrantType::IMPLICIT,
             GrantType::REFRESH_TOKEN,
         ];
 

--- a/src/Factory/GrantTypeFactory.php
+++ b/src/Factory/GrantTypeFactory.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use League\OAuth2\Server\Grant\AuthCodeGrant;
 use League\OAuth2\Server\Grant\ClientCredentialsGrant;
 use League\OAuth2\Server\Grant\GrantTypeInterface;
+use League\OAuth2\Server\Grant\ImplicitGrant;
 use League\OAuth2\Server\Grant\RefreshTokenGrant;
 use Pdsinterop\Solid\Auth\Config\Expiration;
 use Pdsinterop\Solid\Auth\Enum\OAuth2\GrantType;
@@ -52,6 +53,10 @@ class GrantTypeFactory
                 $grant = $this->createClientCredentialsGrant();
                 break;
 
+            case GrantType::IMPLICIT:
+                $grant = $this->createImplicitGrant($expiration->forAccessToken());
+                break;
+
             case GrantType::REFRESH_TOKEN:
                 $grant = $this->createRefreshTokenGrant($factory);
                 break;
@@ -86,6 +91,11 @@ class GrantTypeFactory
             $factory->createRefreshTokenRepository(),
             $expiration
         );
+    }
+
+    private function createImplicitGrant(DateInterval $expiration) : ImplicitGrant
+    {
+        return new ImplicitGrant($expiration);
     }
 
     private function createRefreshTokenGrant(RepositoryFactory $factory) : RefreshTokenGrant


### PR DESCRIPTION
As the "Implicit" grant type is already supported by the underlying library, the only change(s) that is needed is adding infrastructure for creating an Implicit Grant object.