### PR TITLE
Fix dpop

### DIFF
--- a/src/Utils/DPop.php
+++ b/src/Utils/DPop.php
@@ -157,6 +157,7 @@ class DPop {
      * See also: https://datatracker.ietf.org/doc/html/draft-ietf-oauth-dpop#section-7
      * 
 	 * Validates the above part of the oauth dpop specification
+	 *
 	 * @param  string $jwt  JWT access token, raw
 	 * @param  string $dpop DPoP token, raw
 	 * @param  ServerRequestInterface $request Server Request
@@ -165,16 +166,17 @@ class DPop {
 	public function validateJwtDpop($jwt, $dpop, $request) {
 		$this->validateDpop($dpop, $request);
 		$jwtConfig = Configuration::forUnsecuredSigner();
-		$dpopJWT = $jwtConfig->parser()->parse($dpop);
-		
-		$ath = $dpopJWT->claims()->get('ath');
-		if ($ath === null) {
-			throw new InvalidTokenException('DPoP "ath" claim is missing');
-		}
-		
-		$hash    = hash('sha256', $jwt);
-		$encoded = Base64Url::encode($hash);
-		return ($ath === $encoded);
+		$jwtConfig->parser()->parse($dpop);
+
+		/**
+		 * @FIXME: ATH claim is not yet supported/required by the Solid OIDC specification.
+		 *         Once the Solid spec catches up to the DPOP spec, not having an ATH is incorrect.
+		 *         At that point, instead of returning "true", throw an exception:
+		 *
+		 * @see https://github.com/pdsinterop/php-solid-auth/issues/34
+		 */
+		// throw new InvalidTokenException('DPoP "ath" claim is missing');
+		return true;
 	}
 
 	/**

--- a/tests/unit/Utils/DPOPTest.php
+++ b/tests/unit/Utils/DPOPTest.php
@@ -518,6 +518,36 @@ class DPOPTest extends AbstractTestCase
     }
 
     /**
+     * @testdox Dpop SHOULD not complain WHEN asked to get WebId from Request with valid DPOP without "ath"
+     *
+     * @covers ::getWebId
+     *
+     * @uses \Pdsinterop\Solid\Auth\Utils\DPop::getDpopKey
+     * @uses \Pdsinterop\Solid\Auth\Utils\DPop::validateDpop
+     * @uses \Pdsinterop\Solid\Auth\Utils\DPop::validateJwtDpop
+     */
+    final public function testGetWebIdWithDpopWithoutOptionalAth(): void
+    {
+        unset($this->dpop['payload']['ath']);
+        $token = $this->sign($this->dpop);
+
+        $mockJtiValidator = $this->createMockJtiValidator();
+        $mockJtiValidator->expects($this->once())
+            ->method('validate')
+            ->willReturn(true)
+        ;
+        $dpop = new DPop($mockJtiValidator);
+
+        $request = new ServerRequest(array(
+            'HTTP_AUTHORIZATION' => "dpop {$this->accessToken['token']}",
+            'HTTP_DPOP' => $token['token'],
+        ),array(), $this->url);
+
+        $webId = $dpop->getWebId($request);
+
+        $this->assertEquals(self::MOCK_SUBJECT, $webId);
+    }
+    /**
      * @testdox Dpop SHOULD complain WHEN asked to get WebId from Request with valid DPOP without "ath"
      *
      * @covers ::getWebId
@@ -526,8 +556,11 @@ class DPOPTest extends AbstractTestCase
      * @uses \Pdsinterop\Solid\Auth\Utils\DPop::validateDpop
      * @uses \Pdsinterop\Solid\Auth\Utils\DPop::validateJwtDpop
      */
-    final public function testGetWebIdWithDpopWithoutAth(): void
+    final public function testGetWebIdWithDpopWithoutRequiredAth(): void
     {
+        /*/ @see https://github.com/pdsinterop/php-solid-auth/issues/34 /*/
+        $this->markTestSkipped('ATH claim is not yet supported/required by the Solid OIDC specification.');
+
         unset($this->dpop['payload']['ath']);
         $token = $this->sign($this->dpop);
 


### PR DESCRIPTION
- Change `DPop::validateJwtDpop()` to make ATH claim optional. (see #34)
- Fix issue in TokenGenerator caused by incorrect JWK thumbnail (JKT) being returned.
