### PR TITLE
add key ID to the ID token, used for non-dpop applications

### DIFF
--- a/src/Config/KeysInterface.php
+++ b/src/Config/KeysInterface.php
@@ -3,7 +3,7 @@
 namespace Pdsinterop\Solid\Auth\Config;
 
 use Defuse\Crypto\Key as CryptoKey;
-use Lcobucci\JWT\Signer\Key\InMemory as Key;
+use Lcobucci\JWT\Signer\Key as Key;
 use League\OAuth2\Server\CryptKey;
 
 interface KeysInterface

--- a/src/Utils/Bearer.php
+++ b/src/Utils/Bearer.php
@@ -95,7 +95,7 @@ class Bearer {
 	 */
 	public function validateIdToken($token, $request) {
 		$jwtConfig = Configuration::forUnsecuredSigner();
-		$jwtConfig->parser()->parse($jwt);
+		$jwtConfig->parser()->parse($token);
 		return true;
 	}
 

--- a/src/Utils/Bearer.php
+++ b/src/Utils/Bearer.php
@@ -1,0 +1,141 @@
+<?php declare(strict_types=1);
+
+namespace Pdsinterop\Solid\Auth\Utils;
+
+use DateInterval;
+use Exception;
+use Jose\Component\Core\JWK;
+use Jose\Component\Core\Util\ECKey;
+use Jose\Component\Core\Util\RSAKey;
+use Lcobucci\Clock\SystemClock;
+use Lcobucci\JWT\Configuration;
+use Lcobucci\JWT\Signer\Ecdsa\Sha256;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use Lcobucci\JWT\Token\InvalidTokenStructure;
+use Lcobucci\JWT\Validation\Constraint\LooseValidAt;
+use Lcobucci\JWT\Validation\Constraint\SignedWith;
+use Lcobucci\JWT\Validation\RequiredConstraintsViolated;
+use Pdsinterop\Solid\Auth\Exception\AuthorizationHeaderException;
+use Pdsinterop\Solid\Auth\Exception\InvalidTokenException;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * This class contains code to fetch the WebId from a request
+ * that is make in legacy mode (bearer token with pop)
+ */
+class Bearer {
+
+    private JtiValidator $jtiValidator;
+
+	public function __construct(JtiValidator $jtiValidator)
+	{
+		$this->jtiValidator = $jtiValidator;
+	}
+
+	/**
+	 * This method fetches the WebId from a request and verifies
+	 * that the request has a valid pop token that matches
+	 * the access token.
+	 *
+	 * @param ServerRequestInterface $request Server Request
+	 *
+	 * @return string the WebId, or "public" if no WebId is found
+	 *
+	 * @throws Exception "Invalid token" when the pop token is invalid
+	 */
+	public function getWebId($request) {
+		$serverParams = $request->getServerParams();
+
+		if (empty($serverParams['HTTP_AUTHORIZATION'])) {
+			$webId = "public";
+		} else {
+			$this->validateRequestHeaders($serverParams);
+
+			[, $jwt] = explode(" ", $serverParams['HTTP_AUTHORIZATION'], 2);
+
+			try {
+				$this->validateJwt($jwt, $request);
+			} catch (RequiredConstraintsViolated $e) {
+				throw new InvalidTokenException($e->getMessage(), 0, $e);
+			}
+			$idToken = $this->getIdTokenFromJwt($jwt);
+
+			try {
+				$this->validateIdToken($idToken, $request);
+			} catch (RequiredConstraintsViolated $e) {
+				throw new InvalidTokenException($e->getMessage(), 0, $e);
+			}
+			$webId = $this->getSubjectFromIdToken($idToken);
+		}
+
+		return $webId;
+	}
+
+	/**
+	 * @param  string $jwt  JWT access token, raw
+	 * @param  ServerRequestInterface $request Server Request
+	 * @return bool
+	 *
+	 * FIXME: Add more validations to the token;
+	 */
+	public function validateJwt($jwt, $request) {
+		$jwtConfig = Configuration::forUnsecuredSigner();
+		$jwtConfig->parser()->parse($jwt);
+		return true;
+	}
+
+	/**
+	 * validates that the provided OIDC ID Token
+	 * @param  string $token The OIDS ID Token (raw)
+	 * @param  ServerRequestInterface $request Server Request
+	 * @return bool          True if the id token is valid
+	 * @throws InvalidTokenException when the tokens is not valid
+	 *
+	 * FIXME: Add more validations to the token;
+	 */
+	public function validateIdToken($token, $request) {
+		$jwtConfig = Configuration::forUnsecuredSigner();
+		$jwtConfig->parser()->parse($jwt);
+		return true;
+	}
+
+	private function getIdTokenFromJwt($jwt) {
+		$jwtConfig = Configuration::forUnsecuredSigner();
+		try {
+			$jwt = $jwtConfig->parser()->parse($jwt);
+		} catch(Exception $e) {
+			throw new InvalidTokenException("Invalid JWT token", 409, $e);
+		}
+
+		$idToken = $jwt->claims()->get("id_token");
+		if ($idToken === null) {
+			throw new InvalidTokenException('Missing "id_token"');
+		}
+		return $idToken;
+	}
+
+	private function getSubjectFromIdToken($idToken) {
+		$jwtConfig = Configuration::forUnsecuredSigner();
+		try {
+			$jwt = $jwtConfig->parser()->parse($idToken);
+		} catch(Exception $e) {
+			throw new InvalidTokenException("Invalid ID token", 409, $e);
+		}
+
+		$sub = $jwt->claims()->get("sub");
+		if ($sub === null) {
+			throw new InvalidTokenException('Missing "sub"');
+		}
+		return $sub;
+	}
+
+	private function validateRequestHeaders($serverParams) {
+		if (str_contains($serverParams['HTTP_AUTHORIZATION'], ' ') === false) {
+			throw new AuthorizationHeaderException("Authorization Header does not contain parameters");
+		}
+
+		if (str_starts_with(strtolower($serverParams['HTTP_AUTHORIZATION']), 'bearer') === false) {
+			throw new AuthorizationHeaderException('Only "bearer" authorization scheme is supported');
+		}
+	}
+}

--- a/src/Utils/Jwks.php
+++ b/src/Utils/Jwks.php
@@ -3,7 +3,7 @@
 namespace Pdsinterop\Solid\Auth\Utils;
 
 use JsonSerializable;
-use Lcobucci\JWT\Signer\Key\InMemory;
+use Lcobucci\JWT\Signer\Key as Key;
 use Pdsinterop\Solid\Auth\Enum\Jwk\Parameter as JwkParameter;
 use Pdsinterop\Solid\Auth\Enum\Rsa\Parameter as RsaParameter;
 
@@ -11,12 +11,12 @@ class Jwks implements JsonSerializable
 {
     ////////////////////////////// CLASS PROPERTIES \\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
-    /** @var InMemory */
+    /** @var Key */
     private $publicKey;
 
     //////////////////////////////// PUBLIC API \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
-    final public function __construct(InMemory $publicKey)
+    final public function __construct(Key $publicKey)
     {
         $this->publicKey = $publicKey;
     }
@@ -64,9 +64,8 @@ class Jwks implements JsonSerializable
 
         $publicKeys = [$this->publicKey];
 
-        array_walk($publicKeys, function (InMemory $publicKey) use (&$jwks) {
+        array_walk($publicKeys, function (Key $publicKey) use (&$jwks) {
             $certificate = $publicKey->contents();
-
             $key = openssl_pkey_get_public($certificate);
             $keyInfo = openssl_pkey_get_details($key);
 

--- a/tests/unit/TokenGeneratorTest.php
+++ b/tests/unit/TokenGeneratorTest.php
@@ -305,6 +305,22 @@ class TokenGeneratorTest extends AbstractTestCase
             ->willReturn('mock issuer')
         ;
 
+        $publicKey = file_get_contents(__DIR__.'/../fixtures/keys/public.key');
+
+        $mockPublicKey = $this->getMockBuilder(\Lcobucci\JWT\Signer\Key::class)
+            ->getMock()
+        ;
+
+        $mockPublicKey->expects($this->once())
+            ->method('contents')
+            ->willReturn($publicKey)
+        ;
+
+        $this->mockKeys->expects($this->once())
+            ->method('getPublicKey')
+            ->willReturn($this->mockPublicKey)
+        ;
+
         $privateKey = file_get_contents(__DIR__.'/../fixtures/keys/private.key');
 
         $now = new \DateTimeImmutable('1234-01-01 12:34:56.789');
@@ -323,6 +339,7 @@ class TokenGeneratorTest extends AbstractTestCase
             [
                 'typ' => 'JWT',
                 'alg' => 'RS256',
+                'kid' => '0c3932ca20f3a00ad2eb72035f6cc9cb'
             ],
             [
                 'at_hash' => '1EZBnvsFWlK8ESkgHQsrIQ',

--- a/tests/unit/TokenGeneratorTest.php
+++ b/tests/unit/TokenGeneratorTest.php
@@ -281,6 +281,8 @@ class TokenGeneratorTest extends AbstractTestCase
      * @testdox Token Generator SHOULD generate a token without Confirmation JWT Thumbprint (CNF JKT) WHEN asked to generate a IdToken without dpopKey
      *
      * @covers ::generateIdToken
+     *
+     * @uses \Pdsinterop\Solid\Auth\Utils\Jwks
      */
     final public function testIdTokenGenerationWithoutDpopKey(): void
     {

--- a/tests/unit/TokenGeneratorTest.php
+++ b/tests/unit/TokenGeneratorTest.php
@@ -318,7 +318,7 @@ class TokenGeneratorTest extends AbstractTestCase
 
         $this->mockKeys->expects($this->once())
             ->method('getPublicKey')
-            ->willReturn($this->mockPublicKey)
+            ->willReturn($mockPublicKey)
         ;
 
         $privateKey = file_get_contents(__DIR__.'/../fixtures/keys/private.key');


### PR DESCRIPTION
This PR re-adds the key ID to the ID token for the case where we have a non-dpop client. This is needed to get the poddit demo from the solid-nextcloud launcher working.