### PR TITLE
add implementation for rfc-9207

### DIFF
--- a/src/Config/Server.php
+++ b/src/Config/Server.php
@@ -41,6 +41,7 @@ class Server implements ServerInterface
             OidcMeta::JWKS_URI,
             OidcMeta::RESPONSE_TYPES_SUPPORTED,
             OidcMeta::SUBJECT_TYPES_SUPPORTED,
+            OidcMeta::AUTHORIZATION_RESPONSE_ISS_PARAMETER_SUPPORTED // required as per https://solid.github.io/solid-oidc/#iss-check
         ];
 
         if ($this->strict === true) {
@@ -57,23 +58,24 @@ class Server implements ServerInterface
         $data = array_merge([
             OidcMeta::ID_TOKEN_SIGNING_ALG_VALUES_SUPPORTED => ['RS256'],
             OidcMeta::SUBJECT_TYPES_SUPPORTED =>  ['public'],
-			OidcMeta::RESPONSE_TYPES_SUPPORTED => array("code","code token","code id_token","id_token code","id_token","id_token token","code id_token token","none"),
-			OidcMeta::TOKEN_TYPES_SUPPORTED => array("legacyPop","dpop"),
-			OidcMeta::RESPONSE_MODES_SUPPORTED => array("query","fragment"),
-			OidcMeta::GRANT_TYPES_SUPPORTED => array("authorization_code","implicit","refresh_token","client_credentials"),
-			OidcMeta::TOKEN_ENDPOINT_AUTH_METHODS_SUPPORTED => ["client_secret_basic"],
-			OidcMeta::TOKEN_ENDPOINT_AUTH_SIGNING_ALG_VALUES_SUPPORTED => ["RS256"],
-			OidcMeta::CODE_CHALLENGE_METHODS_SUPPORTED => ["S256"],
-			OidcMeta::DPOP_SIGNING_ALG_VALUES_SUPPORTED => ["RS256"],
-			OidcMeta::DISPLAY_VALUES_SUPPORTED => [],
-			OidcMeta::CLAIM_TYPES_SUPPORTED => ["normal"],
-			OidcMeta::CLAIMS_SUPPORTED => ["webid"],
-			OidcMeta::SCOPES_SUPPORTED => ["webid"],
-			OidcMeta::CLAIMS_PARAMETER_SUPPORTED => false,
-			OidcMeta::REQUEST_PARAMETER_SUPPORTED => true,
-			OidcMeta::REQUEST_URI_PARAMETER_SUPPORTED => false,
-			OidcMeta::REQUIRE_REQUEST_URI_REGISTRATION => false
-		], $data);
+            OidcMeta::RESPONSE_TYPES_SUPPORTED => array("code","code token","code id_token","id_token code","id_token","id_token token","code id_token token","none"),
+            OidcMeta::TOKEN_TYPES_SUPPORTED => array("legacyPop","dpop"),
+            OidcMeta::RESPONSE_MODES_SUPPORTED => array("query","fragment"),
+            OidcMeta::GRANT_TYPES_SUPPORTED => array("authorization_code","implicit","refresh_token","client_credentials"),
+            OidcMeta::TOKEN_ENDPOINT_AUTH_METHODS_SUPPORTED => "client_secret_basic",
+            OidcMeta::TOKEN_ENDPOINT_AUTH_SIGNING_ALG_VALUES_SUPPORTED => ["RS256"],
+            OidcMeta::CODE_CHALLENGE_METHODS_SUPPORTED => ["S256"],
+            OidcMeta::DPOP_SIGNING_ALG_VALUES_SUPPORTED => ["RS256"],
+            OidcMeta::DISPLAY_VALUES_SUPPORTED => [],
+            OidcMeta::CLAIM_TYPES_SUPPORTED => ["normal"],
+            OidcMeta::CLAIMS_SUPPORTED => ["webid"],
+            OidcMeta::SCOPES_SUPPORTED => ["webid"],
+            OidcMeta::CLAIMS_PARAMETER_SUPPORTED => false,
+            OidcMeta::REQUEST_PARAMETER_SUPPORTED => true,
+            OidcMeta::REQUEST_URI_PARAMETER_SUPPORTED => false,
+            OidcMeta::REQUIRE_REQUEST_URI_REGISTRATION => false,
+            OidcMeta::AUTHORIZATION_RESPONSE_ISS_PARAMETER_SUPPORTED => true
+        ], $data);
 
         $this->data = array_filter($data, [OidcMeta::class, 'has'], ARRAY_FILTER_USE_KEY);
         $this->strict = $strict;

--- a/src/Config/Server.php
+++ b/src/Config/Server.php
@@ -62,7 +62,7 @@ class Server implements ServerInterface
             OidcMeta::TOKEN_TYPES_SUPPORTED => array("legacyPop","dpop"),
             OidcMeta::RESPONSE_MODES_SUPPORTED => array("query","fragment"),
             OidcMeta::GRANT_TYPES_SUPPORTED => array("authorization_code","implicit","refresh_token","client_credentials"),
-            OidcMeta::TOKEN_ENDPOINT_AUTH_METHODS_SUPPORTED => "client_secret_basic",
+            OidcMeta::TOKEN_ENDPOINT_AUTH_METHODS_SUPPORTED => ["client_secret_basic"],
             OidcMeta::TOKEN_ENDPOINT_AUTH_SIGNING_ALG_VALUES_SUPPORTED => ["RS256"],
             OidcMeta::CODE_CHALLENGE_METHODS_SUPPORTED => ["S256"],
             OidcMeta::DPOP_SIGNING_ALG_VALUES_SUPPORTED => ["RS256"],

--- a/src/Enum/OpenId/OpenIdConnectMetadata.php
+++ b/src/Enum/OpenId/OpenIdConnectMetadata.php
@@ -223,4 +223,5 @@ class OpenIdConnectMetadata extends AbstractEnum
 	public const TOKEN_TYPES_SUPPORTED = 'token_types_supported';
 	public const CHECK_SESSION_IFRAME = 'check_session_iframe';
 	public const END_SESSION_ENDPOINT = 'end_session_endpoint';
+	public const AUTHORIZATION_RESPONSE_ISS_PARAMETER_SUPPORTED = 'authorization_response_iss_parameter_supported'; // as per [RFC9207]
 }

--- a/src/Server.php
+++ b/src/Server.php
@@ -40,10 +40,12 @@ class Server
         $response = $this->response;
 
         try {
-            return $authorizationServer->respondToAccessTokenRequest($request, $response);
+            $response = $authorizationServer->respondToAccessTokenRequest($request, $response);
         } catch (OAuthServerException $serverException) {
-            return $this->createOauthServerExceptionResponse($response, $serverException);
+            $response = $this->createOauthServerExceptionResponse($response, $serverException);
         }
+        $response = $this->addIssuerToResponse($response);
+        return $response;
     }
 
     /**
@@ -71,7 +73,9 @@ class Server
             // Validate the HTTP request and return an AuthorizationRequest object.
             $authRequest = $authorizationServer->validateAuthorizationRequest($request);
         } catch (OAuthServerException $serverException) {
-            return $this->createOauthServerExceptionResponse($response, $serverException);
+            $response = $this->createOauthServerExceptionResponse($response, $serverException);
+            $response = $this->addIssuerToResponse($response);
+            return $response;
         }
 
         if ($user instanceof UserEntityInterface) {

--- a/src/Server.php
+++ b/src/Server.php
@@ -95,6 +95,7 @@ class Server
 
             // Return the HTTP redirect response
             $response = $authorizationServer->completeAuthorizationRequest($authRequest, $response);
+            $this->addIssuerToResponse($response); // add  &iss=... to the response to comply with RFC 9207
         } else {
             // @CHECKME: 404 or throw Exception?
             $response = $response->withStatus(404);
@@ -105,6 +106,25 @@ class Server
             // @CHECKME: Should this give access to the League\OAuth2 object or do we need to inject a Pdsinterop\Solid intermediate?
             $callback($authRequest);
         }
+
+        return $response;
+    }
+
+    public function addIssuerToResponse($response): Response
+    {
+        // Adds &iss=... to the response to comply with RFC 9207
+        $location = $response->getHeaderLine('Location');
+        $uri = new Uri($location);
+
+        parse_str($uri->getQuery(), $params);
+        $params['iss'] = $this->config->getServer()->get(OidcMeta::ISSUER);
+
+        $uri = $uri->withQuery(http_build_query($params));
+
+        $response = $response->withHeader(
+            'Location',
+            (string) $uri
+        );
 
         return $response;
     }

--- a/tests/unit/Config/ServerTest.php
+++ b/tests/unit/Config/ServerTest.php
@@ -121,7 +121,7 @@ class ServerTest extends TestCase
             'code_challenge_methods_supported' => ['S256'],
             'dpop_signing_alg_values_supported' => ['RS256'],
             'scopes_supported' => ['webid'],
-            'authorization_response_iss_parameter_supported' => true,',
+            'authorization_response_iss_parameter_supported' => true,
         ], $actual);
     }
 }

--- a/tests/unit/Config/ServerTest.php
+++ b/tests/unit/Config/ServerTest.php
@@ -41,6 +41,7 @@ class ServerTest extends TestCase
             OidcMeta::JWKS_URI,
             OidcMeta::RESPONSE_TYPES_SUPPORTED,
             OidcMeta::SUBJECT_TYPES_SUPPORTED,
+            OidcMeta::AUTHORIZATION_RESPONSE_ISS_PARAMETER_SUPPORTED,
         ];
 
         self::assertEquals($expected, $actual);
@@ -119,7 +120,8 @@ class ServerTest extends TestCase
             'require_request_uri_registration' => false,
             'code_challenge_methods_supported' => ['S256'],
             'dpop_signing_alg_values_supported' => ['RS256'],
-            'scopes_supported' => ['webid']
+            'scopes_supported' => ['webid'],
+            'authorization_response_iss_parameter_supported' => true,',
         ], $actual);
     }
 }

--- a/tests/unit/Enum/OpenId/OpenIdConnectMetadataTest.php
+++ b/tests/unit/Enum/OpenId/OpenIdConnectMetadataTest.php
@@ -56,7 +56,8 @@ class OpenIdConnectMetadataTest extends TestCase
             'userinfo_signing_alg_values_supported',
             'token_types_supported',
             'check_session_iframe',
-            'end_session_endpoint'
+            'end_session_endpoint',
+            'authorization_response_iss_parameter_supported'
         ];
     }
 


### PR DESCRIPTION
- adds &iss={issuer} to the authorization redirect
- adds the entry in the well-known/openid-configuration
- adds tests

Fixes #52 
Supercedes https://github.com/pdsinterop/php-solid-auth/pull/54