### PR TITLE
Add check for 'ath' claim

### DIFF
--- a/src/Utils/DPop.php
+++ b/src/Utils/DPop.php
@@ -166,17 +166,18 @@ class DPop {
 	public function validateJwtDpop($jwt, $dpop, $request) {
 		$this->validateDpop($dpop, $request);
 		$jwtConfig = Configuration::forUnsecuredSigner();
-		$jwtConfig->parser()->parse($dpop);
+		$dpopJWT = $jwtConfig->parser()->parse($dpop);
+		
+		$ath = $dpopJWT->claims()->get('ath');
 
-		/**
-		 * @FIXME: ATH claim is not yet supported/required by the Solid OIDC specification.
-		 *         Once the Solid spec catches up to the DPOP spec, not having an ATH is incorrect.
-		 *         At that point, instead of returning "true", throw an exception:
-		 *
-		 * @see https://github.com/pdsinterop/php-solid-auth/issues/34
-		 */
-		// throw new InvalidTokenException('DPoP "ath" claim is missing');
-		return true;
+		if ($ath === null) {
+			throw new InvalidTokenException('DPoP "ath" claim is missing');
+		}
+		
+		$hash    = hash('sha256', $jwt);
+		$encoded = Base64Url::encode($hash);
+	
+		return ($ath === $encoded);
 	}
 
 	/**


### PR DESCRIPTION
Updated JWT DPoP validation to check for 'ath' claim and throw an exception if missing.

Resolves #34
 - - -

Marked as drafft until unit-tests are added and Applications have been tested.